### PR TITLE
Syntax fix in dune-project dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,5 +20,4 @@
  (synopsis "The Baguette# Interpreter REPL")
  (description "The REPL for Baguette#")
  (depends
- {"ocaml">=4.13.1})
- )
+  (ocaml (>= 4.13.1))))


### PR DESCRIPTION
[Dune's documentation](https://dune.readthedocs.io/en/stable/dune-files.html#package) mentions the syntax for package dependencies. Until [recently](https://github.com/ocaml/dune/commit/0afc32068985b2a6b05837453b93b96b7512182d), this syntax was not checked at all. It is now, and since this package is included in the giant monorepo benchmarks we run on dune, they are failing.